### PR TITLE
Small fix on READM.md for PDF documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ demonstration. Partial output of `demo.tex`") -->
 ## Getting started
 
 After having added the package, you can add LaTeX in two ways:
+
 * Inline style:
 
       Your file begins with a line of the form \hll|\documentclass[]{}|. The


### PR DESCRIPTION
The first item in the Markdown list was not rendered correctly in the PDF (Getting started > Inline style), so I inserted a blank line before it.
I don't know the procedure for generating PDFs, but I think this probably fixed the problem (Here, I used Pandoc to check: `$ pandoc -o output.pdf README.md`).

Before:

![Screen Shot 2021-03-17 at 12 29 17](https://user-images.githubusercontent.com/29575029/111410620-6f3c7800-871c-11eb-8397-dc19d24e4a43.png)

After:

![Screen Shot 2021-03-17 at 12 28 38](https://user-images.githubusercontent.com/29575029/111410663-81b6b180-871c-11eb-9582-39984d738eaf.png)
